### PR TITLE
import slack -> slack_sdk, in the style of Slack SDK v3.

### DIFF
--- a/acrank/acrank.py
+++ b/acrank/acrank.py
@@ -4,7 +4,7 @@ import requests
 from collections import defaultdict
 import os
 from datetime import datetime
-from slack import WebClient
+from slack_sdk import WebClient
 import argparse
 
 # Example:


### PR DESCRIPTION
This change should be applied AFTER `pip install slack-sdk`, since it destroys back-compatibility with Slack SDK v2.